### PR TITLE
Allow passing any env variable to `BootstrapPimcore::bootstrap()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## next
+
+### Breaking Changes:
+
+- `Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore::bootstrap()` now expects named arguments.<br>
+  If you pass the application environment as a parameter, you now have to prefix it with: `APP_ENV:`:
+  ```diff
+  -BootstrapPimcore::bootstrap('something')
+  +BootstrapPimcore::bootstrap(APP_ENV: 'something')
+  ```
+- The second parameter (`$value`) of `Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore::setEnv()`
+  is now of type `string`.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,15 @@ include dirname(__DIR__).'/vendor/autoload.php';
 Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore::bootstrap();
 ```
 
-There's also `BootstrapPimcore::setEnv()` to set environment variables during the bootstrap process.
+You can also pass any environment variable via named arguments to this method:
 
-> **Hint**: you can pass the application environment (`APP_ENV`) directly as a parameter of 
-> `BootstrapPimcore::bootstrap()` (it defaults to `test`).
+```php
+# tests/bootstrap.php
+Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore::bootstrap(
+    APP_ENV: 'custom',
+    SOMETHING: 'else',
+);
+```
 
 #### Integration Tests For a Bundle
 
@@ -48,9 +53,10 @@ use Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore;
 
 include dirname(__DIR__).'/vendor/autoload.php';
 
-BootstrapPimcore::setEnv('PIMCORE_PROJECT_ROOT', __DIR__.'/app');
-BootstrapPimcore::setEnv('KERNEL_CLASS', TestKernel::class);
-BootstrapPimcore::bootstrap();
+BootstrapPimcore::bootstrap(
+    PIMCORE_PROJECT_ROOT: __DIR__.'/app',
+    KERNEL_CLASS: TestKernel::class,
+);
 ```
 
 > **Note**: Don't forget to create the `tests/app` directory!

--- a/src/Pimcore/BootstrapPimcore.php
+++ b/src/Pimcore/BootstrapPimcore.php
@@ -8,18 +8,21 @@ use Pimcore\Bootstrap;
 
 final class BootstrapPimcore
 {
-    public static function bootstrap(string $env = 'test'): void
+    private const DEFAULT_ENV_VARS = [
+        'APP_ENV' => 'test',
+    ];
+
+    public static function bootstrap(string ...$envVars): void
     {
-        self::setEnv('APP_ENV', $env);
+        foreach ($envVars + self::DEFAULT_ENV_VARS as $name => $value) {
+            self::setEnv($name, $value);
+        }
 
         Bootstrap::setProjectRoot();
         Bootstrap::bootstrap();
     }
 
-    /**
-     * @param mixed $value
-     */
-    public static function setEnv(string $name, $value): void
+    public static function setEnv(string $name, string $value): void
     {
         putenv("{$name}=".$_ENV[$name] = $_SERVER[$name] = $value);
     }


### PR DESCRIPTION
Instead of only allowing to pass the `APP_ENV` as a parameter, we should allow passing any env variable, as it's common to set more, like: `PIMCORE_PROJECT_ROOT` or `KERNEL_CLASS`.

> **Note**
> This feature requires PHP 8, so we may want to drop Pimcore 6 / PHP 7 support prior to merging this.