### PR TITLE
Drop Pimcore 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,13 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ~8.0.0 || ~8.1.0",
-        "doctrine/persistence": "^1.3.3 || ^2.1.0",
-        "pimcore/pimcore": "^6.3.6 || ^10.0",
+        "php": "~8.1.0",
+        "doctrine/persistence": "^2.1.0",
+        "pimcore/pimcore": "^10.5",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^3.4 || ^4.4 || ^5.2",
-        "symfony/filesystem": "^3.4 || ^4.4 || ^5.2",
-        "symfony/framework-bundle": "^3.4 || ^4.4 || ^5.2",
-        "symfony/polyfill-php80": "^1.24"
+        "symfony/console": "^5.4",
+        "symfony/filesystem": "^5.4",
+        "symfony/framework-bundle": "^5.4"
     },
     "require-dev": {
         "dama/doctrine-test-bundle": "^6.0",


### PR DESCRIPTION
This also drops PHP 8.0 support, as it's almost EOL (in 5 months).