### PR TITLE
Remove support for Pimcore `11.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": "~8.1.0 || ~8.2.0",
     "doctrine/annotations": "^1.5",
     "doctrine/persistence": "^2.1 || ^3.0",
-    "pimcore/pimcore": "^10.5 || ^11.0",
+    "pimcore/pimcore": "^10.5 || ~11.0.0 || ~11.1.0",
     "psr/log": "^1.0 || ^2.0 || ^3.0",
     "symfony/console": "^5.4 || ^6.2",
     "symfony/filesystem": "^5.4 || ^6.2",


### PR DESCRIPTION
We currently cannot support Pimcore `11.2` because of https://github.com/pimcore/pimcore/pull/16730, where `Pimcore\Bundle\InstallBundle\Installer::insertDatabaseDump()` was made `private`, so we can no longer overwrite it, which breaks our installer.

I proposed a fix here: https://github.com/pimcore/pimcore/pull/16797
Once this has been merged, we will add the support again.