### PR TITLE
Fix type definition for `ConfgureExtension`

### DIFF
--- a/src/Kernel/CompatibilityKernel.php
+++ b/src/Kernel/CompatibilityKernel.php
@@ -24,7 +24,7 @@ if (!method_exists(Version::class, 'getMajorVersion') || 10 === Version::getMajo
         /**
          * @internal
          *
-         * @var array<string, array<mixed>>
+         * @var array<string, mixed>
          */
         protected array $testExtensionConfigs = [];
 
@@ -66,7 +66,7 @@ if (!method_exists(Version::class, 'getMajorVersion') || 10 === Version::getMajo
         /**
          * @internal
          *
-         * @var array<string, array<mixed>>
+         * @var array<string, mixed>
          */
         protected array $testExtensionConfigs = [];
 

--- a/src/Kernel/TestKernel.php
+++ b/src/Kernel/TestKernel.php
@@ -36,7 +36,7 @@ class TestKernel extends CompatibilityKernel
     }
 
     /**
-     * @param array<string, array<mixed>> $config
+     * @param array<string, mixed> $config
      */
     public function addTestExtensionConfig(string $namespace, array $config): void
     {

--- a/src/Test/Attribute/ConfigureExtension.php
+++ b/src/Test/Attribute/ConfigureExtension.php
@@ -9,7 +9,7 @@ use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 final class ConfigureExtension implements KernelConfiguration
 {
     /**
-     * @param array<string, array<mixed>> $extensionConfig
+     * @param array<string, mixed> $extensionConfig
      */
     public function __construct(
         private readonly string $namespace,


### PR DESCRIPTION
In my particular case I am applying this configuration:

```
#[ConfigureExtension('neusta_pimcore_cache_invalidation', ['listeners' => true])]
```

This corresponds to:

```yaml
neusta_pimcore_cache_invalidation:
  listeners: true
```
