### PR TITLE
Restructure the package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## v0.13.0
 ### Changes:
-- Deprecated `Neusta\Pimcore\TestingFramework\Kernel\TestKernel` in favor of `Neusta\Pimcore\TestingFramework\TestKernel`
-- Deprecated `Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore` in favor of `Neusta\Pimcore\TestingFramework\BootstrapPimcore`
-- Deprecated `Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase` in favor of `Neusta\Pimcore\TestingFramework\KernelTestCase`
+- Deprecated `Neusta\Pimcore\TestingFramework\Kernel\TestKernel` 
+  in favor of `Neusta\Pimcore\TestingFramework\TestKernel`
+- Deprecated `Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore` 
+  in favor of `Neusta\Pimcore\TestingFramework\BootstrapPimcore`
+- Deprecated `Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase` 
+  in favor of `Neusta\Pimcore\TestingFramework\KernelTestCase`
+- Deprecated `Neusta\Pimcore\TestingFramework\Test\Attribute\KernelConfiguration` 
+  in favor of `\Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel`
+- Deprecated `Neusta\Pimcore\TestingFramework\Test\Attribute\{ConfigureContainer,ConfigureExtension,RegisterBundle,RegisterCompilerPass}` 
+  in favor of `\Neusta\Pimcore\TestingFramework\Attribute\Kernel\{ConfigureContainer,ConfigureExtension,RegisterBundle,RegisterCompilerPass}`
 
 ## v0.12.4
 ### Bugfixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changes:
 - Deprecated `Neusta\Pimcore\TestingFramework\Kernel\TestKernel` in favor of `Neusta\Pimcore\TestingFramework\TestKernel`
 - Deprecated `Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore` in favor of `Neusta\Pimcore\TestingFramework\BootstrapPimcore`
+- Deprecated `Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase` in favor of `Neusta\Pimcore\TestingFramework\KernelTestCase`
 
 ## v0.12.4
 ### Bugfixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.13.0
 ### Changes:
 - Deprecated `Neusta\Pimcore\TestingFramework\Kernel\TestKernel` in favor of `Neusta\Pimcore\TestingFramework\TestKernel`
+- Deprecated `Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore` in favor of `Neusta\Pimcore\TestingFramework\BootstrapPimcore`
 
 ## v0.12.4
 ### Bugfixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.13.0
+### Changes:
+- Deprecated `Neusta\Pimcore\TestingFramework\Kernel\TestKernel` in favor of `Neusta\Pimcore\TestingFramework\TestKernel`
+
 ## v0.12.4
 ### Bugfixes:
 - Fix type definition for `ConfgureExtension`

--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ To enable it again, you can use the `WithAdminMode` trait.
 
 The `TestKernel` can be configured dynamically for each test.
 This is useful if different configurations or dependent bundles are to be tested.
-To do this, your test class must inherit from `ConfigurableKernelTestCase`:
+To do this, your test class must inherit from `KernelTestCase`:
 
 ```php
-use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
+use Neusta\Pimcore\TestingFramework\KernelTestCase;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 
-class SomeTest extends ConfigurableKernelTestCase
+class SomeTest extends KernelTestCase
 {
     public function test_bundle_with_different_configuration(): void
     {
@@ -130,18 +130,18 @@ class SomeTest extends ConfigurableKernelTestCase
 
 #### Attributes
 
-An alternative to passing a `config` closure in the `options` array to `ConfigurableKernelTestCase::bootKernel()` 
+An alternative to passing a `config` closure in the `options` array to `KernelTestCase::bootKernel()` 
 is to use attributes for the kernel configuration.
 
 ```php
+use Neusta\Pimcore\TestingFramework\KernelTestCase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureContainer;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterBundle;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterCompilerPass;
-use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
 
 #[RegisterBundle(SomeBundle::class)]
-class SomeTest extends ConfigurableKernelTestCase 
+class SomeTest extends KernelTestCase 
 {
     #[ConfigureContainer(__DIR__ . '/Fixtures/some_config.yaml')]
     #[ConfigureExtension('some_extension', ['config' => 'values'])]
@@ -164,10 +164,10 @@ You can also use the `RegisterBundle`, `ConfigureContainer`, `ConfigureExtension
 to configure the kernel in a data provider.
 
 ```php
+use Neusta\Pimcore\TestingFramework\KernelTestCase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
-use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
 
-class SomeTest extends ConfigurableKernelTestCase 
+class SomeTest extends KernelTestCase 
 {
     public function provideTestData(): iterable
     {

--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ An alternative to passing a `config` closure in the `options` array to `KernelTe
 is to use attributes for the kernel configuration.
 
 ```php
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\ConfigureContainer;
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\ConfigureExtension;
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\RegisterBundle;
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\RegisterCompilerPass;
 use Neusta\Pimcore\TestingFramework\KernelTestCase;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureContainer;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterBundle;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterCompilerPass;
 
 #[RegisterBundle(SomeBundle::class)]
 class SomeTest extends KernelTestCase 
@@ -164,8 +164,8 @@ You can also use the `RegisterBundle`, `ConfigureContainer`, `ConfigureExtension
 to configure the kernel in a data provider.
 
 ```php
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\ConfigureExtension;
 use Neusta\Pimcore\TestingFramework\KernelTestCase;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
 
 class SomeTest extends KernelTestCase 
 {
@@ -199,11 +199,11 @@ class SomeTest extends KernelTestCase
 You can create your own kernel configuration attributes by implementing the `KernelConfiguration` interface:
 
 ```php
-use Neusta\Pimcore\TestingFramework\Test\Attribute\KernelConfiguration;
+use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
-class ConfigureSomeBundle implements KernelConfiguration
+class ConfigureSomeBundle implements ConfigureKernel
 {
     public function __construct(
         private readonly array $config,

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ For a basic setup, you can use the `TestKernel` directly:
 # tests/bootstrap.php
 <?php
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 use Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 
 include dirname(__DIR__).'/vendor/autoload.php';
 
@@ -103,8 +103,8 @@ This is useful if different configurations or dependent bundles are to be tested
 To do this, your test class must inherit from `ConfigurableKernelTestCase`:
 
 ```php
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 
 class SomeTest extends ConfigurableKernelTestCase
 {
@@ -199,8 +199,8 @@ class SomeTest extends ConfigurableKernelTestCase
 You can create your own kernel configuration attributes by implementing the `KernelConfiguration` interface:
 
 ```php
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\KernelConfiguration;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
 class ConfigureSomeBundle implements KernelConfiguration

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ Just call `BootstrapPimcore::bootstrap()` in your `tests/bootstrap.php` as seen 
 
 include dirname(__DIR__).'/vendor/autoload.php';
 
-Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore::bootstrap();
+\Neusta\Pimcore\TestingFramework\BootstrapPimcore::bootstrap();
 ```
 
 You can also pass any environment variable via named arguments to this method:
 
 ```php
 # tests/bootstrap.php
-Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore::bootstrap(
+\Neusta\Pimcore\TestingFramework\BootstrapPimcore::bootstrap(
     APP_ENV: 'custom',
     SOMETHING: 'else',
 );
@@ -52,7 +52,7 @@ For a basic setup, you can use the `TestKernel` directly:
 # tests/bootstrap.php
 <?php
 
-use Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore;
+use Neusta\Pimcore\TestingFramework\BootstrapPimcore;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 
 include dirname(__DIR__).'/vendor/autoload.php';

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -7,6 +7,9 @@ return (new Configuration())
     // Exclude test app
     ->addPathToExclude(__DIR__ . '/tests/app')
 
+    // Ignore packages that the analyzer does not recognize
+    ->ignoreErrorsOnPackage('symfony/deprecation-contracts', [ErrorType::UNUSED_DEPENDENCY])
+
     // Ignore optional dependency
     ->ignoreErrorsOnPackageAndPath('dama/doctrine-test-bundle', __DIR__ . '/src/Database/ResetDatabase.php', [ErrorType::DEV_DEPENDENCY_IN_PROD])
     ->ignoreErrorsOnPackageAndPath('dama/doctrine-test-bundle', __DIR__ . '/src/Database/DatabaseResetter.php', [ErrorType::DEV_DEPENDENCY_IN_PROD])

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "symfony/config": "^5.4 || ^6.4",
     "symfony/console": "^5.4 || ^6.4",
     "symfony/dependency-injection": "^5.4 || ^6.4",
+    "symfony/deprecation-contracts": "^2.1 || ^3.0",
     "symfony/event-dispatcher": "^5.4 || ^6.4",
     "symfony/filesystem": "^5.4 || ^6.4",
     "symfony/framework-bundle": "^5.4 || ^6.4",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,6 +36,6 @@ parameters:
 			path: src/Database/RunCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of static method Neusta\\\\Pimcore\\\\TestingFramework\\\\Pimcore\\\\BootstrapPimcore\\:\\:setEnv\\(\\) expects string, int\\|string given\\.$#"
+			message: "#^Parameter \\#1 \\$name of static method Neusta\\\\Pimcore\\\\TestingFramework\\\\BootstrapPimcore\\:\\:setEnv\\(\\) expects string, int\\|string given\\.$#"
 			count: 1
-			path: src/Pimcore/BootstrapPimcore.php
+			path: src/BootstrapPimcore.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,7 +10,7 @@ parameters:
 
 	excludePaths:
 		# There are two errors, that were not able to be added to the baseline
-		- src/Kernel/CompatibilityKernel.php
+		- src/Internal/CompatibilityTestKernel.php
 		# Deprecated aliases
 		- src/Kernel/TestKernel.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,7 @@ parameters:
 		# Deprecated aliases
 		- src/Kernel/TestKernel.php
 		- src/Pimcore/BootstrapPimcore.php
+		- src/Test/*
 
 	bootstrapFiles:
 		- vendor/pimcore/pimcore/stubs/dynamic-constants.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,7 @@ parameters:
 		- src/Internal/CompatibilityTestKernel.php
 		# Deprecated aliases
 		- src/Kernel/TestKernel.php
+		- src/Pimcore/BootstrapPimcore.php
 
 	bootstrapFiles:
 		- vendor/pimcore/pimcore/stubs/dynamic-constants.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,8 @@ parameters:
 	excludePaths:
 		# There are two errors, that were not able to be added to the baseline
 		- src/Kernel/CompatibilityKernel.php
+		# Deprecated aliases
+		- src/Kernel/TestKernel.php
 
 	bootstrapFiles:
 		- vendor/pimcore/pimcore/stubs/dynamic-constants.php

--- a/src/Attribute/ConfigureKernel.php
+++ b/src/Attribute/ConfigureKernel.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Attribute;
+
+use Neusta\Pimcore\TestingFramework\TestKernel;
+
+interface ConfigureKernel
+{
+    public function configure(TestKernel $kernel): void;
+}

--- a/src/Attribute/Kernel/ConfigureContainer.php
+++ b/src/Attribute/Kernel/ConfigureContainer.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Attribute\Kernel;
+
+use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel;
+use Neusta\Pimcore\TestingFramework\TestKernel;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class ConfigureContainer implements ConfigureKernel
+{
+    /**
+     * @param string|\Closure(ContainerBuilder):void $config path to a config file or a closure which gets the {@see ContainerBuilder} as its first argument
+     */
+    public function __construct(
+        private readonly string|\Closure $config,
+    ) {
+    }
+
+    public function configure(TestKernel $kernel): void
+    {
+        $kernel->addTestConfig($this->config);
+    }
+}

--- a/src/Attribute/Kernel/ConfigureExtension.php
+++ b/src/Attribute/Kernel/ConfigureExtension.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Attribute\Kernel;
+
+use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel;
+use Neusta\Pimcore\TestingFramework\TestKernel;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class ConfigureExtension implements ConfigureKernel
+{
+    /**
+     * @param array<string, mixed> $extensionConfig
+     */
+    public function __construct(
+        private readonly string $namespace,
+        private readonly array $extensionConfig,
+    ) {
+    }
+
+    public function configure(TestKernel $kernel): void
+    {
+        $kernel->addTestExtensionConfig($this->namespace, $this->extensionConfig);
+    }
+}

--- a/src/Attribute/Kernel/RegisterBundle.php
+++ b/src/Attribute/Kernel/RegisterBundle.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Attribute\Kernel;
+
+use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel;
+use Neusta\Pimcore\TestingFramework\TestKernel;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class RegisterBundle implements ConfigureKernel
+{
+    /**
+     * @param class-string<BundleInterface> $bundle
+     */
+    public function __construct(
+        private readonly string $bundle,
+    ) {
+    }
+
+    public function configure(TestKernel $kernel): void
+    {
+        $kernel->addTestBundle($this->bundle);
+    }
+}

--- a/src/Attribute/Kernel/RegisterCompilerPass.php
+++ b/src/Attribute/Kernel/RegisterCompilerPass.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Attribute\Kernel;
+
+use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel;
+use Neusta\Pimcore\TestingFramework\TestKernel;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class RegisterCompilerPass implements ConfigureKernel
+{
+    /**
+     * @param PassConfig::TYPE_* $type
+     */
+    public function __construct(
+        private readonly CompilerPassInterface $compilerPass,
+        private readonly string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION,
+        private readonly int $priority = 0,
+    ) {
+    }
+
+    public function configure(TestKernel $kernel): void
+    {
+        $kernel->addTestCompilerPass($this->compilerPass, $this->type, $this->priority);
+    }
+}

--- a/src/BootstrapPimcore.php
+++ b/src/BootstrapPimcore.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework;
+
+use Neusta\Pimcore\TestingFramework\Pimcore\AdminMode;
+use Pimcore\Bootstrap;
+
+final class BootstrapPimcore
+{
+    private const DEFAULT_ENV_VARS = [
+        'APP_ENV' => 'test',
+    ];
+
+    public static function bootstrap(string ...$envVars): void
+    {
+        foreach ($envVars + self::DEFAULT_ENV_VARS as $name => $value) {
+            self::setEnv($name, $value);
+        }
+
+        Bootstrap::setProjectRoot();
+        Bootstrap::bootstrap();
+        AdminMode::disable();
+    }
+
+    public static function setEnv(string $name, string $value): void
+    {
+        putenv("{$name}=" . $_ENV[$name] = $_SERVER[$name] = $value);
+    }
+}

--- a/src/Database/ResetDatabase.php
+++ b/src/Database/ResetDatabase.php
@@ -6,7 +6,7 @@ namespace Neusta\Pimcore\TestingFramework\Database;
 
 use DAMA\DoctrineTestBundle\Doctrine\DBAL\StaticDriver;
 use Neusta\Pimcore\TestingFramework\Exception\DoesNotExtendKernelTestCase;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Pimcore\Test\KernelTestCase;
 
 /**
  * @mixin KernelTestCase

--- a/src/Exception/DoesNotExtendKernelTestCase.php
+++ b/src/Exception/DoesNotExtendKernelTestCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Exception;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Pimcore\Test\KernelTestCase;
 
 final class DoesNotExtendKernelTestCase extends \RuntimeException
 {
@@ -13,7 +13,7 @@ final class DoesNotExtendKernelTestCase extends \RuntimeException
         return new self(\sprintf(
             'The trait "%s" can only be used on TestCases that extend "%s".',
             $trait,
-            KernelTestCase::class
+            KernelTestCase::class,
         ));
     }
 }

--- a/src/Internal/CompatibilityTestKernel.php
+++ b/src/Internal/CompatibilityTestKernel.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Neusta\Pimcore\TestingFramework\Kernel;
+namespace Neusta\Pimcore\TestingFramework\Internal;
 
 use Pimcore\Bundle\AdminBundle\PimcoreAdminBundle;
 use Pimcore\HttpKernel\BundleCollection\BundleCollection;
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 
 if (!method_exists(Version::class, 'getMajorVersion') || 10 === Version::getMajorVersion()) {
     /** @internal */
-    abstract class CompatibilityKernel extends Kernel
+    abstract class CompatibilityTestKernel extends Kernel
     {
         /**
          * @internal
@@ -55,7 +55,7 @@ if (!method_exists(Version::class, 'getMajorVersion') || 10 === Version::getMajo
     }
 } else {
     /** @internal */
-    abstract class CompatibilityKernel extends Kernel
+    abstract class CompatibilityTestKernel extends Kernel
     {
         /**
          * @internal

--- a/src/Kernel/TestKernel.php
+++ b/src/Kernel/TestKernel.php
@@ -3,120 +3,23 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Kernel;
 
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Neusta\Pimcore\TestingFramework\TestKernel as RootTestKernel;
 
-class TestKernel extends CompatibilityKernel
-{
-    private bool $dynamicCache = false;
-    /** @var list<class-string<BundleInterface>> */
-    private array $testBundles = [];
-    /** @var list<array{CompilerPassInterface, string, int}> */
-    private array $testCompilerPasses = [];
+trigger_deprecation(
+    'teamneusta/pimcore-testing-framework',
+    '0.13',
+    'The "%s" class is deprecated, use "%s" instead.',
+    TestKernel::class,
+    RootTestKernel::class,
+);
 
+class_alias(RootTestKernel::class, TestKernel::class);
+
+if (false) {
     /**
-     * @param class-string<BundleInterface> $bundleClass
+     * @deprecated since 0.13, use Neusta\Pimcore\TestingFramework\TestKernel instead
      */
-    public function addTestBundle(string $bundleClass): void
+    class TestKernel extends RootTestKernel
     {
-        $this->testBundles[] = $bundleClass;
-        $this->dynamicCache = true;
-    }
-
-    /**
-     * @param string|callable(ContainerBuilder):void $config path to a config file or a callable which gets the {@see ContainerBuilder} as its first argument
-     */
-    public function addTestConfig(string|callable $config): void
-    {
-        $this->testConfigs[] = $config;
-        $this->dynamicCache = true;
-    }
-
-    /**
-     * @param array<string, mixed> $config
-     */
-    public function addTestExtensionConfig(string $namespace, array $config): void
-    {
-        $this->testExtensionConfigs[$namespace] = $config;
-        $this->dynamicCache = true;
-    }
-
-    /**
-     * @param PassConfig::TYPE_* $type
-     */
-    public function addTestCompilerPass(
-        CompilerPassInterface $compilerPass,
-        string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION,
-        int $priority = 0,
-    ): void {
-        $this->testCompilerPasses[] = [$compilerPass, $type, $priority];
-        $this->dynamicCache = true;
-    }
-
-    /**
-     * @param array{config?: callable(static):void, ...} $options
-     */
-    public function handleOptions(array $options): void
-    {
-        if (\is_callable($configure = $options['config'] ?? null)) {
-            $configure($this);
-        }
-    }
-
-    public function getCacheDir(): string
-    {
-        if ($this->dynamicCache) {
-            return rtrim(parent::getCacheDir(), '/') . '/' . spl_object_hash($this);
-        }
-
-        return parent::getCacheDir();
-    }
-
-    /**
-     * @return array<BundleInterface>
-     */
-    public function registerBundles(): array
-    {
-        $bundles = parent::registerBundles();
-
-        if ([] === $this->testBundles) {
-            return $bundles;
-        }
-
-        $bundleClasses = [];
-        foreach ($bundles as $bundle) {
-            $bundleClasses[$bundle::class] = true;
-        }
-
-        foreach (array_unique($this->testBundles) as $class) {
-            if (!isset($bundleClasses[$class])) {
-                $bundles[] = new $class();
-            }
-        }
-
-        return $bundles;
-    }
-
-    protected function buildContainer(): ContainerBuilder
-    {
-        $container = parent::buildContainer();
-
-        foreach ($this->testCompilerPasses as $compilerPass) {
-            $container->addCompilerPass(...$compilerPass);
-        }
-
-        return $container;
-    }
-
-    public function shutdown(): void
-    {
-        parent::shutdown();
-
-        if ($this->dynamicCache) {
-            (new Filesystem())->remove($this->getCacheDir());
-        }
     }
 }

--- a/src/KernelTestCase.php
+++ b/src/KernelTestCase.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework;
 
-use Neusta\Pimcore\TestingFramework\Test\Attribute\KernelConfiguration;
+use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel;
 use PHPUnit\Framework\TestCase;
 
 abstract class KernelTestCase extends \Pimcore\Test\KernelTestCase
 {
-    /** @var list<KernelConfiguration> */
+    /** @var list<ConfigureKernel> */
     private static iterable $kernelConfigurations = [];
 
     /**
@@ -40,17 +40,17 @@ abstract class KernelTestCase extends \Pimcore\Test\KernelTestCase
         $providedData = $this->getProvidedData();
         $configurations = [];
 
-        foreach ($class->getAttributes(KernelConfiguration::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+        foreach ($class->getAttributes(ConfigureKernel::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             $configurations[] = $attribute->newInstance();
         }
 
-        foreach ($method->getAttributes(KernelConfiguration::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+        foreach ($method->getAttributes(ConfigureKernel::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             $configurations[] = $attribute->newInstance();
         }
 
         if ([] !== $providedData) {
             foreach ($providedData as $data) {
-                if ($data instanceof KernelConfiguration) {
+                if ($data instanceof ConfigureKernel) {
                     $configurations[] = $data;
                 }
             }
@@ -58,7 +58,7 @@ abstract class KernelTestCase extends \Pimcore\Test\KernelTestCase
             // remove them from the arguments passed to the test method
             (new \ReflectionProperty(TestCase::class, 'data'))->setValue($this, array_values(array_filter(
                 $providedData,
-                fn ($data) => !$data instanceof KernelConfiguration,
+                fn ($data) => !$data instanceof ConfigureKernel,
             )));
         }
 

--- a/src/KernelTestCase.php
+++ b/src/KernelTestCase.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework;
+
+use Neusta\Pimcore\TestingFramework\Test\Attribute\KernelConfiguration;
+use PHPUnit\Framework\TestCase;
+
+abstract class KernelTestCase extends \Pimcore\Test\KernelTestCase
+{
+    /** @var list<KernelConfiguration> */
+    private static iterable $kernelConfigurations = [];
+
+    /**
+     * @param array{config?: callable(TestKernel):void, environment?: string, debug?: bool, ...} $options
+     */
+    protected static function createKernel(array $options = []): TestKernel
+    {
+        $kernel = parent::createKernel($options);
+        \assert($kernel instanceof TestKernel);
+
+        foreach (self::$kernelConfigurations as $configuration) {
+            $configuration->configure($kernel);
+        }
+
+        $kernel->handleOptions($options);
+
+        return $kernel;
+    }
+
+    /**
+     * @internal
+     *
+     * @before
+     */
+    public function _getKernelConfigurationFromAttributes(): void
+    {
+        $class = new \ReflectionClass($this);
+        $method = $class->getMethod($this->getName(false));
+        $providedData = $this->getProvidedData();
+        $configurations = [];
+
+        foreach ($class->getAttributes(KernelConfiguration::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            $configurations[] = $attribute->newInstance();
+        }
+
+        foreach ($method->getAttributes(KernelConfiguration::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            $configurations[] = $attribute->newInstance();
+        }
+
+        if ([] !== $providedData) {
+            foreach ($providedData as $data) {
+                if ($data instanceof KernelConfiguration) {
+                    $configurations[] = $data;
+                }
+            }
+
+            // remove them from the arguments passed to the test method
+            (new \ReflectionProperty(TestCase::class, 'data'))->setValue($this, array_values(array_filter(
+                $providedData,
+                fn ($data) => !$data instanceof KernelConfiguration,
+            )));
+        }
+
+        self::$kernelConfigurations = $configurations;
+    }
+
+    protected function tearDown(): void
+    {
+        self::$kernelConfigurations = [];
+        parent::tearDown();
+    }
+}

--- a/src/Pimcore/BootstrapPimcore.php
+++ b/src/Pimcore/BootstrapPimcore.php
@@ -1,30 +1,32 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Pimcore;
 
-use Pimcore\Bootstrap;
+use Neusta\Pimcore\TestingFramework\BootstrapPimcore as RootBootstrapPimcore;
 
-final class BootstrapPimcore
-{
-    private const DEFAULT_ENV_VARS = [
-        'APP_ENV' => 'test',
-    ];
+trigger_deprecation(
+    'teamneusta/pimcore-testing-framework',
+    '0.13',
+    'The "%s" class is deprecated, use "%s" instead.',
+    BootstrapPimcore::class,
+    RootBootstrapPimcore::class,
+);
 
-    public static function bootstrap(string ...$envVars): void
+class_alias(RootBootstrapPimcore::class, BootstrapPimcore::class);
+
+if (false) {
+    /**
+     * @deprecated since 0.13, use Neusta\Pimcore\TestingFramework\BootstrapPimcore instead
+     */
+    final class BootstrapPimcore
     {
-        foreach ($envVars + self::DEFAULT_ENV_VARS as $name => $value) {
-            self::setEnv($name, $value);
+        public static function bootstrap(string ...$envVars): void
+        {
         }
 
-        Bootstrap::setProjectRoot();
-        Bootstrap::bootstrap();
-        AdminMode::disable();
-    }
-
-    public static function setEnv(string $name, string $value): void
-    {
-        putenv("{$name}=" . $_ENV[$name] = $_SERVER[$name] = $value);
+        public static function setEnv(string $name, string $value): void
+        {
+        }
     }
 }

--- a/src/Pimcore/WithoutCache.php
+++ b/src/Pimcore/WithoutCache.php
@@ -6,7 +6,7 @@ namespace Neusta\Pimcore\TestingFramework\Pimcore;
 
 use Neusta\Pimcore\TestingFramework\Exception\DoesNotExtendKernelTestCase;
 use Pimcore\Cache;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Pimcore\Test\KernelTestCase;
 
 /**
  * @mixin KernelTestCase

--- a/src/Test/Attribute/ConfigureContainer.php
+++ b/src/Test/Attribute/ConfigureContainer.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]

--- a/src/Test/Attribute/ConfigureContainer.php
+++ b/src/Test/Attribute/ConfigureContainer.php
@@ -3,22 +3,24 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
 
-use Neusta\Pimcore\TestingFramework\TestKernel;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\ConfigureContainer as NewConfigureContainer;
 
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-final class ConfigureContainer implements KernelConfiguration
-{
+trigger_deprecation(
+    'teamneusta/pimcore-testing-framework',
+    '0.13',
+    'The "%s" attribute is deprecated, use "%s" instead.',
+    ConfigureContainer::class,
+    NewConfigureContainer::class,
+);
+
+class_alias(NewConfigureContainer::class, ConfigureContainer::class);
+
+if (false) {
     /**
-     * @param string|\Closure(ContainerBuilder):void $config path to a config file or a closure which gets the {@see ContainerBuilder} as its first argument
+     * @deprecated since 0.13, use Neusta\Pimcore\TestingFramework\Attribute\Kernel\ConfigureContainer instead
      */
-    public function __construct(
-        private readonly string|\Closure $config,
-    ) {
-    }
-
-    public function configure(TestKernel $kernel): void
+    #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+    class ConfigureContainer
     {
-        $kernel->addTestConfig($this->config);
     }
 }

--- a/src/Test/Attribute/ConfigureExtension.php
+++ b/src/Test/Attribute/ConfigureExtension.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class ConfigureExtension implements KernelConfiguration

--- a/src/Test/Attribute/ConfigureExtension.php
+++ b/src/Test/Attribute/ConfigureExtension.php
@@ -3,22 +3,24 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
 
-use Neusta\Pimcore\TestingFramework\TestKernel;
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\ConfigureExtension as NewConfigureExtension;
 
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-final class ConfigureExtension implements KernelConfiguration
-{
+trigger_deprecation(
+    'teamneusta/pimcore-testing-framework',
+    '0.13',
+    'The "%s" attribute is deprecated, use "%s" instead.',
+    ConfigureExtension::class,
+    NewConfigureExtension::class,
+);
+
+class_alias(NewConfigureExtension::class, ConfigureExtension::class);
+
+if (false) {
     /**
-     * @param array<string, mixed> $extensionConfig
+     * @deprecated since 0.13, use Neusta\Pimcore\TestingFramework\Attribute\Kernel\ConfigureExtension instead
      */
-    public function __construct(
-        private readonly string $namespace,
-        private readonly array $extensionConfig,
-    ) {
-    }
-
-    public function configure(TestKernel $kernel): void
+    #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+    class ConfigureExtension
     {
-        $kernel->addTestExtensionConfig($this->namespace, $this->extensionConfig);
     }
 }

--- a/src/Test/Attribute/KernelConfiguration.php
+++ b/src/Test/Attribute/KernelConfiguration.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 
 interface KernelConfiguration
 {

--- a/src/Test/Attribute/KernelConfiguration.php
+++ b/src/Test/Attribute/KernelConfiguration.php
@@ -3,9 +3,23 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
 
-use Neusta\Pimcore\TestingFramework\TestKernel;
+use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel;
 
-interface KernelConfiguration
-{
-    public function configure(TestKernel $kernel): void;
+trigger_deprecation(
+    'teamneusta/pimcore-testing-framework',
+    '0.13',
+    'The "%s" interface is deprecated, use "%s" instead.',
+    KernelConfiguration::class,
+    ConfigureKernel::class,
+);
+
+class_alias(ConfigureKernel::class, KernelConfiguration::class);
+
+if (false) {
+    /**
+     * @deprecated since 0.13, use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel instead
+     */
+    interface KernelConfiguration extends ConfigureKernel
+    {
+    }
 }

--- a/src/Test/Attribute/RegisterBundle.php
+++ b/src/Test/Attribute/RegisterBundle.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]

--- a/src/Test/Attribute/RegisterBundle.php
+++ b/src/Test/Attribute/RegisterBundle.php
@@ -3,22 +3,24 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
 
-use Neusta\Pimcore\TestingFramework\TestKernel;
-use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\RegisterBundle as NewRegisterBundle;
 
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-final class RegisterBundle implements KernelConfiguration
-{
+trigger_deprecation(
+    'teamneusta/pimcore-testing-framework',
+    '0.13',
+    'The "%s" attribute is deprecated, use "%s" instead.',
+    RegisterBundle::class,
+    NewRegisterBundle::class,
+);
+
+class_alias(NewRegisterBundle::class, RegisterBundle::class);
+
+if (false) {
     /**
-     * @param class-string<BundleInterface> $bundle
+     * @deprecated since 0.13, use Neusta\Pimcore\TestingFramework\Attribute\Kernel\RegisterBundle instead
      */
-    public function __construct(
-        private readonly string $bundle,
-    ) {
-    }
-
-    public function configure(TestKernel $kernel): void
+    #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+    class RegisterBundle
     {
-        $kernel->addTestBundle($this->bundle);
     }
 }

--- a/src/Test/Attribute/RegisterCompilerPass.php
+++ b/src/Test/Attribute/RegisterCompilerPass.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 

--- a/src/Test/Attribute/RegisterCompilerPass.php
+++ b/src/Test/Attribute/RegisterCompilerPass.php
@@ -3,25 +3,24 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
 
-use Neusta\Pimcore\TestingFramework\TestKernel;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\RegisterCompilerPass as NewRegisterCompilerPass;
 
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-final class RegisterCompilerPass implements KernelConfiguration
-{
+trigger_deprecation(
+    'teamneusta/pimcore-testing-framework',
+    '0.13',
+    'The "%s" attribute is deprecated, use "%s" instead.',
+    RegisterCompilerPass::class,
+    NewRegisterCompilerPass::class,
+);
+
+class_alias(NewRegisterCompilerPass::class, RegisterCompilerPass::class);
+
+if (false) {
     /**
-     * @param PassConfig::TYPE_* $type
+     * @deprecated since 0.13, use Neusta\Pimcore\TestingFramework\Attribute\Kernel\RegisterCompilerPass instead
      */
-    public function __construct(
-        private readonly CompilerPassInterface $compilerPass,
-        private readonly string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION,
-        private readonly int $priority = 0,
-    ) {
-    }
-
-    public function configure(TestKernel $kernel): void
+    #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+    class RegisterCompilerPass
     {
-        $kernel->addTestCompilerPass($this->compilerPass, $this->type, $this->priority);
     }
 }

--- a/src/Test/ConfigurableKernelTestCase.php
+++ b/src/Test/ConfigurableKernelTestCase.php
@@ -3,73 +3,23 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test;
 
-use Neusta\Pimcore\TestingFramework\Test\Attribute\KernelConfiguration;
-use Neusta\Pimcore\TestingFramework\TestKernel;
-use PHPUnit\Framework\TestCase;
-use Pimcore\Test\KernelTestCase;
+use Neusta\Pimcore\TestingFramework\KernelTestCase;
 
-abstract class ConfigurableKernelTestCase extends KernelTestCase
-{
-    /** @var list<KernelConfiguration> */
-    private static iterable $kernelConfigurations = [];
+trigger_deprecation(
+    'teamneusta/pimcore-testing-framework',
+    '0.13',
+    'The "%s" class is deprecated, use "%s" instead.',
+    ConfigurableKernelTestCase::class,
+    KernelTestCase::class,
+);
 
+class_alias(KernelTestCase::class, ConfigurableKernelTestCase::class);
+
+if (false) {
     /**
-     * @param array{config?: callable(TestKernel):void, environment?: string, debug?: bool, ...} $options
+     * @deprecated since 0.13, use Neusta\Pimcore\TestingFramework\KernelTestCase instead
      */
-    protected static function createKernel(array $options = []): TestKernel
+    abstract class ConfigurableKernelTestCase extends KernelTestCase
     {
-        $kernel = parent::createKernel($options);
-        \assert($kernel instanceof TestKernel);
-
-        foreach (self::$kernelConfigurations as $configuration) {
-            $configuration->configure($kernel);
-        }
-
-        $kernel->handleOptions($options);
-
-        return $kernel;
-    }
-
-    /**
-     * @internal
-     *
-     * @before
-     */
-    public function _getKernelConfigurationFromAttributes(): void
-    {
-        $class = new \ReflectionClass($this);
-        $method = $class->getMethod($this->getName(false));
-        $providedData = $this->getProvidedData();
-        $configurations = [];
-
-        foreach ($class->getAttributes(KernelConfiguration::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-            $configurations[] = $attribute->newInstance();
-        }
-
-        foreach ($method->getAttributes(KernelConfiguration::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
-            $configurations[] = $attribute->newInstance();
-        }
-
-        if ([] !== $providedData) {
-            foreach ($providedData as $data) {
-                if ($data instanceof KernelConfiguration) {
-                    $configurations[] = $data;
-                }
-            }
-
-            // remove them from the arguments passed to the test method
-            (new \ReflectionProperty(TestCase::class, 'data'))->setValue($this, array_values(array_filter(
-                $providedData,
-                fn ($data) => !$data instanceof KernelConfiguration,
-            )));
-        }
-
-        self::$kernelConfigurations = $configurations;
-    }
-
-    protected function tearDown(): void
-    {
-        self::$kernelConfigurations = [];
-        parent::tearDown();
     }
 }

--- a/src/Test/ConfigurableKernelTestCase.php
+++ b/src/Test/ConfigurableKernelTestCase.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Test;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\KernelConfiguration;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 use PHPUnit\Framework\TestCase;
 use Pimcore\Test\KernelTestCase;
 

--- a/src/TestKernel.php
+++ b/src/TestKernel.php
@@ -1,0 +1,123 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework;
+
+use Neusta\Pimcore\TestingFramework\Kernel\CompatibilityKernel;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+class TestKernel extends CompatibilityKernel
+{
+    private bool $dynamicCache = false;
+    /** @var list<class-string<BundleInterface>> */
+    private array $testBundles = [];
+    /** @var list<array{CompilerPassInterface, string, int}> */
+    private array $testCompilerPasses = [];
+
+    /**
+     * @param class-string<BundleInterface> $bundleClass
+     */
+    public function addTestBundle(string $bundleClass): void
+    {
+        $this->testBundles[] = $bundleClass;
+        $this->dynamicCache = true;
+    }
+
+    /**
+     * @param string|callable(ContainerBuilder):void $config path to a config file or a callable which gets the {@see ContainerBuilder} as its first argument
+     */
+    public function addTestConfig(string|callable $config): void
+    {
+        $this->testConfigs[] = $config;
+        $this->dynamicCache = true;
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    public function addTestExtensionConfig(string $namespace, array $config): void
+    {
+        $this->testExtensionConfigs[$namespace] = $config;
+        $this->dynamicCache = true;
+    }
+
+    /**
+     * @param PassConfig::TYPE_* $type
+     */
+    public function addTestCompilerPass(
+        CompilerPassInterface $compilerPass,
+        string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION,
+        int $priority = 0,
+    ): void {
+        $this->testCompilerPasses[] = [$compilerPass, $type, $priority];
+        $this->dynamicCache = true;
+    }
+
+    /**
+     * @param array{config?: callable(static):void, ...} $options
+     */
+    public function handleOptions(array $options): void
+    {
+        if (\is_callable($configure = $options['config'] ?? null)) {
+            $configure($this);
+        }
+    }
+
+    public function getCacheDir(): string
+    {
+        if ($this->dynamicCache) {
+            return rtrim(parent::getCacheDir(), '/') . '/' . spl_object_hash($this);
+        }
+
+        return parent::getCacheDir();
+    }
+
+    /**
+     * @return array<BundleInterface>
+     */
+    public function registerBundles(): array
+    {
+        $bundles = parent::registerBundles();
+
+        if ([] === $this->testBundles) {
+            return $bundles;
+        }
+
+        $bundleClasses = [];
+        foreach ($bundles as $bundle) {
+            $bundleClasses[$bundle::class] = true;
+        }
+
+        foreach (array_unique($this->testBundles) as $class) {
+            if (!isset($bundleClasses[$class])) {
+                $bundles[] = new $class();
+            }
+        }
+
+        return $bundles;
+    }
+
+    protected function buildContainer(): ContainerBuilder
+    {
+        $container = parent::buildContainer();
+
+        foreach ($this->testCompilerPasses as $compilerPass) {
+            $container->addCompilerPass(...$compilerPass);
+        }
+
+        return $container;
+    }
+
+    public function shutdown(): void
+    {
+        parent::shutdown();
+
+        if ($this->dynamicCache) {
+            (new Filesystem())->remove($this->getCacheDir());
+        }
+    }
+}

--- a/src/TestKernel.php
+++ b/src/TestKernel.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework;
 
-use Neusta\Pimcore\TestingFramework\Kernel\CompatibilityKernel;
+use Neusta\Pimcore\TestingFramework\Internal\CompatibilityTestKernel;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
-class TestKernel extends CompatibilityKernel
+class TestKernel extends CompatibilityTestKernel
 {
     private bool $dynamicCache = false;
     /** @var list<class-string<BundleInterface>> */

--- a/tests/Fixtures/Attribute/ConfigureConfigurationBundle.php
+++ b/tests/Fixtures/Attribute/ConfigureConfigurationBundle.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Fixtures\Attribute;
 
-use Neusta\Pimcore\TestingFramework\Test\Attribute\KernelConfiguration;
+use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
-final class ConfigureConfigurationBundle implements KernelConfiguration
+final class ConfigureConfigurationBundle implements ConfigureKernel
 {
     public function __construct(
         private readonly array $config,

--- a/tests/Fixtures/Attribute/ConfigureConfigurationBundle.php
+++ b/tests/Fixtures/Attribute/ConfigureConfigurationBundle.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Fixtures\Attribute;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\KernelConfiguration;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]

--- a/tests/Functional/CompilerPassTest.php
+++ b/tests/Functional/CompilerPassTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\RegisterCompilerPass;
 use Neusta\Pimcore\TestingFramework\KernelTestCase;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterCompilerPass;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\DependencyInjection\Compiler\DeregisterSomethingPass;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\DependencyInjection\Compiler\RegisterSomethingPass;

--- a/tests/Functional/CompilerPassTest.php
+++ b/tests/Functional/CompilerPassTest.php
@@ -3,14 +3,14 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
+use Neusta\Pimcore\TestingFramework\KernelTestCase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterCompilerPass;
-use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\DependencyInjection\Compiler\DeregisterSomethingPass;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\DependencyInjection\Compiler\RegisterSomethingPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 
-final class CompilerPassTest extends ConfigurableKernelTestCase
+final class CompilerPassTest extends KernelTestCase
 {
     /**
      * @test

--- a/tests/Functional/CompilerPassTest.php
+++ b/tests/Functional/CompilerPassTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterCompilerPass;
 use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\DependencyInjection\Compiler\DeregisterSomethingPass;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\DependencyInjection\Compiler\RegisterSomethingPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;

--- a/tests/Functional/ContainerConfigurationTest.php
+++ b/tests/Functional/ContainerConfigurationTest.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureContainer;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterBundle;
 use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/tests/Functional/ContainerConfigurationTest.php
+++ b/tests/Functional/ContainerConfigurationTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\ConfigureContainer;
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\RegisterBundle;
 use Neusta\Pimcore\TestingFramework\KernelTestCase;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureContainer;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterBundle;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;

--- a/tests/Functional/ContainerConfigurationTest.php
+++ b/tests/Functional/ContainerConfigurationTest.php
@@ -3,16 +3,16 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
+use Neusta\Pimcore\TestingFramework\KernelTestCase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureContainer;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterBundle;
-use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 #[RegisterBundle(ConfigurationBundle::class)]
-final class ContainerConfigurationTest extends ConfigurableKernelTestCase
+final class ContainerConfigurationTest extends KernelTestCase
 {
     public function provideDifferentConfigurationFormats(): iterable
     {

--- a/tests/Functional/CustomAttributeTest.php
+++ b/tests/Functional/CustomAttributeTest.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
-use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
+use Neusta\Pimcore\TestingFramework\KernelTestCase;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\Attribute\ConfigureConfigurationBundle;
 
-final class CustomAttributeTest extends ConfigurableKernelTestCase
+final class CustomAttributeTest extends KernelTestCase
 {
     /**
      * @test

--- a/tests/Functional/DataProviderTest.php
+++ b/tests/Functional/DataProviderTest.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
+use Neusta\Pimcore\TestingFramework\KernelTestCase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterBundle;
-use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
 
-final class DataProviderTest extends ConfigurableKernelTestCase
+final class DataProviderTest extends KernelTestCase
 {
     public function provideData(): iterable
     {

--- a/tests/Functional/DataProviderTest.php
+++ b/tests/Functional/DataProviderTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\ConfigureExtension;
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\RegisterBundle;
 use Neusta\Pimcore\TestingFramework\KernelTestCase;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterBundle;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
 
 final class DataProviderTest extends KernelTestCase

--- a/tests/Functional/ExtensionConfigurationTest.php
+++ b/tests/Functional/ExtensionConfigurationTest.php
@@ -3,9 +3,9 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\ConfigureExtension;
+use Neusta\Pimcore\TestingFramework\Attribute\Kernel\RegisterBundle;
 use Neusta\Pimcore\TestingFramework\KernelTestCase;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
-use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterBundle;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
 

--- a/tests/Functional/ExtensionConfigurationTest.php
+++ b/tests/Functional/ExtensionConfigurationTest.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterBundle;
 use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
 
 final class ExtensionConfigurationTest extends ConfigurableKernelTestCase

--- a/tests/Functional/ExtensionConfigurationTest.php
+++ b/tests/Functional/ExtensionConfigurationTest.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
+use Neusta\Pimcore\TestingFramework\KernelTestCase;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureExtension;
 use Neusta\Pimcore\TestingFramework\Test\Attribute\RegisterBundle;
-use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 use Neusta\Pimcore\TestingFramework\Tests\Fixtures\ConfigurationBundle\ConfigurationBundle;
 
-final class ExtensionConfigurationTest extends ConfigurableKernelTestCase
+final class ExtensionConfigurationTest extends KernelTestCase
 {
     /**
      * @test

--- a/tests/Functional/KernelShutdownTest.php
+++ b/tests/Functional/KernelShutdownTest.php
@@ -3,11 +3,11 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
-use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
+use Neusta\Pimcore\TestingFramework\KernelTestCase;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 use Symfony\Component\Filesystem\Filesystem;
 
-class KernelShutdownTest extends ConfigurableKernelTestCase
+class KernelShutdownTest extends KernelTestCase
 {
     /**
      * @test

--- a/tests/Functional/KernelShutdownTest.php
+++ b/tests/Functional/KernelShutdownTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 use Symfony\Component\Filesystem\Filesystem;
 
 class KernelShutdownTest extends ConfigurableKernelTestCase

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
 use Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore;
+use Neusta\Pimcore\TestingFramework\TestKernel;
 
 include dirname(__DIR__) . '/vendor/autoload.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore;
+use Neusta\Pimcore\TestingFramework\BootstrapPimcore;
 use Neusta\Pimcore\TestingFramework\TestKernel;
 
 include dirname(__DIR__) . '/vendor/autoload.php';


### PR DESCRIPTION
### Changes:
- Deprecated `Neusta\Pimcore\TestingFramework\Kernel\TestKernel` 
  in favor of `Neusta\Pimcore\TestingFramework\TestKernel`
- Deprecated `Neusta\Pimcore\TestingFramework\Pimcore\BootstrapPimcore` 
  in favor of `Neusta\Pimcore\TestingFramework\BootstrapPimcore`
- Deprecated `Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase` 
  in favor of `Neusta\Pimcore\TestingFramework\KernelTestCase`
- Deprecated `Neusta\Pimcore\TestingFramework\Test\Attribute\KernelConfiguration` 
  in favor of `\Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel`
- Deprecated `Neusta\Pimcore\TestingFramework\Test\Attribute\{ConfigureContainer,ConfigureExtension,RegisterBundle,RegisterCompilerPass}` 
  in favor of `\Neusta\Pimcore\TestingFramework\Attribute\Kernel\{ConfigureContainer,ConfigureExtension,RegisterBundle,RegisterCompilerPass}`