### PR TITLE
Add `WebTestCase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## v0.13.0
+### Features:
+- Provide a `WebTestCase` with configurable kernel
+
 ### Changes:
 - Deprecated `Neusta\Pimcore\TestingFramework\Kernel\TestKernel` 
   in favor of `Neusta\Pimcore\TestingFramework\TestKernel`

--- a/src/Internal/AttributeProvider.php
+++ b/src/Internal/AttributeProvider.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Internal;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/** @internal */
+final class AttributeProvider
+{
+    /**
+     * @template T
+     *
+     * @param class-string<T> $name
+     *
+     * @return list<T>
+     */
+    public static function getAttributes(KernelTestCase $testCase, string $name): array
+    {
+        $class = new \ReflectionClass($testCase);
+        $method = $class->getMethod($testCase->getName(false));
+
+        $attributes = [
+            ...self::doGetAttributes($class, $name),
+            ...self::doGetAttributes($method, $name),
+            ...self::getAttributesFromProvidedData($testCase, $name),
+        ];
+
+        // remove them from the arguments passed to the test method
+        self::removeAttributesFromProvidedData($testCase, $name);
+
+        return $attributes;
+    }
+
+    /**
+     * @template T
+     *
+     * @param class-string<T> $name
+     *
+     * @return list<T>
+     */
+    private static function doGetAttributes(\ReflectionClass|\ReflectionMethod $source, string $name): array
+    {
+        $attributes = [];
+        foreach ($source->getAttributes($name, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            $attributes[] = $attribute->newInstance();
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @template T
+     *
+     * @param class-string<T> $name
+     *
+     * @return list<T>
+     */
+    private static function getAttributesFromProvidedData(KernelTestCase $testCase, string $name): array
+    {
+        $attributes = [];
+        foreach ($testCase->getProvidedData() as $data) {
+            if ($data instanceof $name) {
+                $attributes[] = $data;
+            }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param class-string $name
+     */
+    private static function removeAttributesFromProvidedData(KernelTestCase $testCase, string $name): void
+    {
+        if ([] === $providedData = $testCase->getProvidedData()) {
+            return;
+        }
+
+        $filteredData = array_values(array_filter($providedData, fn ($data) => !$data instanceof $name));
+
+        (new \ReflectionProperty(TestCase::class, 'data'))->setValue($testCase, $filteredData);
+    }
+}

--- a/src/Internal/ConfigureKernel.php
+++ b/src/Internal/ConfigureKernel.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Internal;
+
+use Neusta\Pimcore\TestingFramework\Exception\DoesNotExtendKernelTestCase;
+use Neusta\Pimcore\TestingFramework\TestKernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @mixin KernelTestCase
+ */
+trait ConfigureKernel
+{
+    /**
+     * @param array{config?: callable(TestKernel):void, environment?: string, debug?: bool, ...} $options
+     */
+    protected static function createKernel(array $options = []): TestKernel
+    {
+        if (!is_subclass_of(static::class, KernelTestCase::class)) {
+            throw DoesNotExtendKernelTestCase::forTrait(__TRAIT__);
+        }
+
+        $kernel = parent::createKernel($options);
+
+        if (!$kernel instanceof TestKernel) {
+            throw new \LogicException(\sprintf('Kernel must be an instance of %s', TestKernel::class));
+        }
+
+        KernelConfigurator::configure($kernel);
+
+        $kernel->handleOptions($options);
+
+        return $kernel;
+    }
+
+    /**
+     * @internal
+     *
+     * @before
+     */
+    public function _collectKernelConfigurations(): void
+    {
+        if (!$this instanceof KernelTestCase) {
+            throw DoesNotExtendKernelTestCase::forTrait(__TRAIT__);
+        }
+
+        KernelConfigurator::up($this);
+    }
+
+    /**
+     * @internal
+     *
+     * @after
+     */
+    public function _resetKernelConfigurations(): void
+    {
+        KernelConfigurator::down();
+    }
+}

--- a/src/Internal/KernelConfigurator.php
+++ b/src/Internal/KernelConfigurator.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Internal;
+
+use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel;
+use Neusta\Pimcore\TestingFramework\TestKernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/** @internal */
+final class KernelConfigurator
+{
+    /** @var list<ConfigureKernel> */
+    private static array $configurators = [];
+
+    public static function up(KernelTestCase $testCase): void
+    {
+        self::$configurators = AttributeProvider::getAttributes($testCase, ConfigureKernel::class);
+    }
+
+    public static function configure(TestKernel $kernel): void
+    {
+        foreach (self::$configurators as $configurator) {
+            $configurator->configure($kernel);
+        }
+    }
+
+    public static function down(): void
+    {
+        self::$configurators = [];
+    }
+}

--- a/src/KernelTestCase.php
+++ b/src/KernelTestCase.php
@@ -3,18 +3,10 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework;
 
-use Neusta\Pimcore\TestingFramework\Attribute\ConfigureKernel;
-use Neusta\Pimcore\TestingFramework\Internal\AttributeProvider;
+use Neusta\Pimcore\TestingFramework\Internal\KernelConfigurator;
 
 abstract class KernelTestCase extends \Pimcore\Test\KernelTestCase
 {
-    /**
-     * @internal
-     *
-     * @var list<ConfigureKernel>
-     */
-    private static array $kernelConfigurations = [];
-
     /**
      * @param array{config?: callable(TestKernel):void, environment?: string, debug?: bool, ...} $options
      */
@@ -26,9 +18,7 @@ abstract class KernelTestCase extends \Pimcore\Test\KernelTestCase
             throw new \LogicException(sprintf('Kernel must be an instance of %s', TestKernel::class));
         }
 
-        foreach (self::$kernelConfigurations as $configuration) {
-            $configuration->configure($kernel);
-        }
+        KernelConfigurator::configure($kernel);
 
         $kernel->handleOptions($options);
 
@@ -42,7 +32,7 @@ abstract class KernelTestCase extends \Pimcore\Test\KernelTestCase
      */
     public function _collectKernelConfigurations(): void
     {
-        self::$kernelConfigurations = AttributeProvider::getAttributes($this, ConfigureKernel::class);
+        KernelConfigurator::up($this);
     }
 
     /**
@@ -52,6 +42,6 @@ abstract class KernelTestCase extends \Pimcore\Test\KernelTestCase
      */
     public function _resetKernelConfigurations(): void
     {
-        self::$kernelConfigurations = [];
+        KernelConfigurator::down();
     }
 }

--- a/src/KernelTestCase.php
+++ b/src/KernelTestCase.php
@@ -3,45 +3,9 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework;
 
-use Neusta\Pimcore\TestingFramework\Internal\KernelConfigurator;
+use Neusta\Pimcore\TestingFramework\Internal\ConfigureKernel;
 
 abstract class KernelTestCase extends \Pimcore\Test\KernelTestCase
 {
-    /**
-     * @param array{config?: callable(TestKernel):void, environment?: string, debug?: bool, ...} $options
-     */
-    protected static function createKernel(array $options = []): TestKernel
-    {
-        $kernel = parent::createKernel($options);
-
-        if (!$kernel instanceof TestKernel) {
-            throw new \LogicException(sprintf('Kernel must be an instance of %s', TestKernel::class));
-        }
-
-        KernelConfigurator::configure($kernel);
-
-        $kernel->handleOptions($options);
-
-        return $kernel;
-    }
-
-    /**
-     * @internal
-     *
-     * @before
-     */
-    public function _collectKernelConfigurations(): void
-    {
-        KernelConfigurator::up($this);
-    }
-
-    /**
-     * @internal
-     *
-     * @after
-     */
-    public function _resetKernelConfigurations(): void
-    {
-        KernelConfigurator::down();
-    }
+    use ConfigureKernel;
 }

--- a/src/WebTestCase.php
+++ b/src/WebTestCase.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework;
+
+use Neusta\Pimcore\TestingFramework\Internal\ConfigureKernel;
+
+abstract class WebTestCase extends \Pimcore\Test\WebTestCase
+{
+    use ConfigureKernel;
+}


### PR DESCRIPTION
Currently, we only provide a `KernelTestCase`, but Symfony/Pimcore also provide a `WebTestCase`, and we should as well.

This is also a preparation for more attributes/features in the future.