### PR TITLE
Disable Asset/Document/DataObject versioning by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## v0.13.0
+### Breaking Changes:
+- Pimcore Asset/Document/DataObject versioning is now disabled by default in 
+  `Neusta\Pimcore\TestingFramework\BootstrapPimcore::bootstrap()`
+
 ### Features:
 - Provide a `WebTestCase` with configurable kernel
 

--- a/src/BootstrapPimcore.php
+++ b/src/BootstrapPimcore.php
@@ -6,6 +6,7 @@ namespace Neusta\Pimcore\TestingFramework;
 
 use Neusta\Pimcore\TestingFramework\Pimcore\AdminMode;
 use Pimcore\Bootstrap;
+use Pimcore\Model\Version;
 
 final class BootstrapPimcore
 {
@@ -22,6 +23,7 @@ final class BootstrapPimcore
         Bootstrap::setProjectRoot();
         Bootstrap::bootstrap();
         AdminMode::disable();
+        Version::disable();
     }
 
     public static function setEnv(string $name, string $value): void


### PR DESCRIPTION
I think we should disable Pimcore versioning by default. Versions shouldn't be needed in tests and will slow them down.