### PR TITLE
Fix importing database dumps on Alpine Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.12.6
+### Bugfixes:
+- Fix importing database dumps on Alpine Linux
+
 ## v0.12.5
 ### Changes:
 - Remove unnecessary `doctrine/annotations` from test suite

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,16 +6,6 @@ parameters:
 			path: src/Database/DatabaseResetter.php
 
 		-
-			message: "#^Method Neusta\\\\Pimcore\\\\TestingFramework\\\\Database\\\\PimcoreInstaller\\:\\:getDataFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Database/PimcoreInstaller.php
-
-		-
-			message: "#^Method Neusta\\\\Pimcore\\\\TestingFramework\\\\Database\\\\PimcoreInstaller\\:\\:getDataFiles\\(\\) should return array but returns array\\<int, string\\>\\|false\\.$#"
-			count: 1
-			path: src/Database/PimcoreInstaller.php
-
-		-
 			message: "#^Parameter \\#1 \\$sql of method Doctrine\\\\DBAL\\\\Connection\\:\\:executeStatement\\(\\) expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/Database/PimcoreInstaller.php


### PR DESCRIPTION
Alpine Linux does not support `GLOB_BRACE`.