### PR TITLE
fix(installer): importing last chunk of SQL dump

### DIFF
--- a/src/Database/PimcoreInstaller.php
+++ b/src/Database/PimcoreInstaller.php
@@ -87,7 +87,7 @@ class PimcoreInstaller extends Installer
             }
 
             // process remaining queries
-            if (count($batchQueries) > 0) {
+            if (\count($batchQueries) > 0) {
                 $db->executeStatement(implode("\n", $batchQueries));
             }
         }

--- a/src/Database/PimcoreInstaller.php
+++ b/src/Database/PimcoreInstaller.php
@@ -86,7 +86,10 @@ class PimcoreInstaller extends Installer
                 }
             }
 
-            $db->executeStatement(implode("\n", $batchQueries));
+            // process remaining queries
+            if (count($batchQueries) > 0) {
+                $db->executeStatement(implode("\n", $batchQueries));
+            }
         }
     }
 


### PR DESCRIPTION
The installer processes the SQL queries in chunks. There is a chance that the remainder chunk will contain zero queries and therefore will result in a PDO exception while trying to execute an empty statement.

This fix checks whether there are queries in the remainder chunk.

See: https://github.com/pimcore/pimcore/pull/17889