### PR TITLE
Add helper for Pimcore backend login

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -7,6 +7,9 @@ return (new Configuration())
     // Exclude test app
     ->addPathToExclude(__DIR__ . '/tests/app')
 
+    // Ignore false-positive unused dependency
+    ->ignoreErrorsOnPackage('symfony/browser-kit', [ErrorType::UNUSED_DEPENDENCY])
+
     // Ignore optional dependency
     ->ignoreErrorsOnPackageAndPath('dama/doctrine-test-bundle', __DIR__ . '/src/Database/ResetDatabase.php', [ErrorType::DEV_DEPENDENCY_IN_PROD])
     ->ignoreErrorsOnPackageAndPath('dama/doctrine-test-bundle', __DIR__ . '/src/Database/DatabaseResetter.php', [ErrorType::DEV_DEPENDENCY_IN_PROD])

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,14 @@
     "phpunit/phpunit": "^9.6.0",
     "pimcore/pimcore": "^10.6 || ~11.0.0 || ~11.1.0 || ~11.2.2 || ~11.3.0 || ~11.4.0",
     "psr/log": "^1.1.3 || ^2.0 || ^3.0",
+    "symfony/browser-kit": "^5.4 || ^6.4",
     "symfony/config": "^5.4 || ^6.4",
     "symfony/console": "^5.4 || ^6.4",
     "symfony/dependency-injection": "^5.4 || ^6.4",
     "symfony/event-dispatcher": "^5.4 || ^6.4",
     "symfony/filesystem": "^5.4 || ^6.4",
     "symfony/framework-bundle": "^5.4 || ^6.4",
+    "symfony/http-foundation": "^5.4 || ^6.4",
     "symfony/http-kernel": "^5.4 || ^6.4"
   },
   "require-dev": {
@@ -43,7 +45,8 @@
     "phpstan/phpstan": "^1.10.60",
     "phpstan/phpstan-phpunit": "^1.3.16",
     "phpstan/phpstan-symfony": "^1.3.8",
-    "shipmonk/composer-dependency-analyser": "^1.7"
+    "shipmonk/composer-dependency-analyser": "^1.7",
+    "symfony/security-core": "^5.4 || ^6.4"
   },
   "suggest": {
     "dama/doctrine-test-bundle": "To isolate database tests in transactions and improve test performance",

--- a/src/Browser/PimcoreKernelBrowser.php
+++ b/src/Browser/PimcoreKernelBrowser.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Browser;
+
+use Pimcore\Model\User;
+use Pimcore\Security\User\User as SecurityUser;
+use Pimcore\Tool\Session;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBagInterface;
+
+class PimcoreKernelBrowser extends KernelBrowser
+{
+    public function loginToPimcoreBackend(string $username = 'admin'): void
+    {
+        if (!$user = User::getByName($username)) {
+            throw new \InvalidArgumentException(\sprintf('User "%s" does not exist.', $username));
+        }
+
+        $this->setServerParameter('HTTP_X_PIMCORE_CSRF_TOKEN', 'test-csrf-token');
+        $this->loginUser(new SecurityUser($user), 'pimcore_admin');
+        $this->request('GET', '/admin/login');
+
+        Session::useBag(
+            $this->getRequest()->getSession(),
+            function (AttributeBagInterface $adminSession) use ($user) {
+                $adminSession->set('user', $user);
+                // Sign your POST requests with this CSRF token to avoid 403 responses
+                $adminSession->set('csrfToken', 'test-csrf-token');
+            },
+        );
+    }
+
+    public function logoutFromPimcoreBackend(): void
+    {
+        Session::useBag(
+            $this->getRequest()->getSession(),
+            function (AttributeBagInterface $adminSession) {
+                $adminSession->set('user', null);
+                $adminSession->set('csrfToken', null);
+            },
+        );
+
+        $this->getCookieJar()->clear();
+    }
+}

--- a/src/Kernel/TestKernel.php
+++ b/src/Kernel/TestKernel.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Neusta\Pimcore\TestingFramework\Kernel;
 
+use Neusta\Pimcore\TestingFramework\Browser\PimcoreKernelBrowser;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -102,6 +103,15 @@ class TestKernel extends CompatibilityKernel
     protected function buildContainer(): ContainerBuilder
     {
         $container = parent::buildContainer();
+
+        $container->addCompilerPass(new class implements CompilerPassInterface {
+            public function process(ContainerBuilder $container): void
+            {
+                if ($container->has('test.client')) {
+                    $container->findDefinition('test.client')->setClass(PimcoreKernelBrowser::class);
+                }
+            }
+        });
 
         foreach ($this->testCompilerPasses as $compilerPass) {
             $container->addCompilerPass(...$compilerPass);

--- a/src/WebTestCase.php
+++ b/src/WebTestCase.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework;
+
+use Neusta\Pimcore\TestingFramework\Browser\PimcoreKernelBrowser;
+
+/**
+ * @method static PimcoreKernelBrowser createClient(array $options = [], array $server = [])
+ */
+class WebTestCase extends \Pimcore\Test\WebTestCase
+{
+}

--- a/tests/Functional/PimcoreKernelBrowserTest.php
+++ b/tests/Functional/PimcoreKernelBrowserTest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
+
+use Neusta\Pimcore\TestingFramework\Database\ResetDatabase;
+use Neusta\Pimcore\TestingFramework\WebTestCase;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+class PimcoreKernelBrowserTest extends WebTestCase
+{
+    use ResetDatabase;
+
+    /**
+     * @test
+     */
+    public function it_allows_logging_in_and_out_from_pimcore_backend(): void
+    {
+        $client = static::createClient();
+        $client->catchExceptions(false);
+
+        // Access should be denied before login
+        try {
+            $client->request('GET', '/admin/user/get-minimal');
+            $this->fail('AccessDeniedException expected.');
+        } catch (AccessDeniedException) {
+        }
+
+        // Access should be granted after login
+        $client->loginToPimcoreBackend();
+        $client->request('GET', '/admin/user/get-minimal');
+        static::assertResponseIsSuccessful();
+
+        // Access should be denied again after logout
+        $client->logoutFromPimcoreBackend();
+        try {
+            $client->request('GET', '/admin/user/get-minimal');
+            $this->fail('AccessDeniedException expected.');
+        } catch (AccessDeniedException) {
+        }
+    }
+}

--- a/tests/app/config/routes.yaml
+++ b/tests/app/config/routes.yaml
@@ -1,0 +1,4 @@
+# auto loads routes from all bundles in config/pimcore/routing.yaml
+_pimcore_bundle_auto:
+  resource: .
+  type: pimcore_bundle


### PR DESCRIPTION
Introduce a custom `PimcoreKernelBrowser` to streamline login/logout in Pimcore backend tests.