### PR TITLE
Add support for dynamic route configuration in `TestKernel`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "symfony/event-dispatcher": "^5.4 || ^6.4",
     "symfony/filesystem": "^5.4 || ^6.4",
     "symfony/framework-bundle": "^5.4 || ^6.4",
-    "symfony/http-kernel": "^5.4 || ^6.4"
+    "symfony/http-kernel": "^5.4 || ^6.4",
+    "symfony/routing": "^5.4 || ^6.4"
   },
   "require-dev": {
     "dama/doctrine-test-bundle": "^6.0 || ^7.0",
@@ -43,7 +44,8 @@
     "phpstan/phpstan": "^1.10.60",
     "phpstan/phpstan-phpunit": "^1.3.16",
     "phpstan/phpstan-symfony": "^1.3.8",
-    "shipmonk/composer-dependency-analyser": "^1.7"
+    "shipmonk/composer-dependency-analyser": "^1.7",
+    "symfony/http-foundation": "^5.4 || ^6.4"
   },
   "conflict": {
     "pimcore/pimcore": ">=11.2.0 <11.2.2"

--- a/src/Kernel/TestKernel.php
+++ b/src/Kernel/TestKernel.php
@@ -7,12 +7,15 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 class TestKernel extends CompatibilityKernel
 {
     private bool $dynamicCache = false;
     /** @var list<class-string<BundleInterface>> */
     private array $testBundles = [];
+    /** @var list<string|callable(RoutingConfigurator):void> */
+    private array $testRoutes = [];
     /** @var list<array{CompilerPassInterface, string, int}> */
     private array $testCompilerPasses = [];
 
@@ -31,6 +34,15 @@ class TestKernel extends CompatibilityKernel
     public function addTestConfig(string|callable $config): void
     {
         $this->testConfigs[] = $config;
+        $this->dynamicCache = true;
+    }
+
+    /**
+     * @param string|callable(RoutingConfigurator):void $config path to a config file or a callable which gets the {@see RoutingConfigurator} as its first argument
+     */
+    public function addTestRoute(string|callable $config): void
+    {
+        $this->testRoutes[] = $config;
         $this->dynamicCache = true;
     }
 
@@ -99,6 +111,19 @@ class TestKernel extends CompatibilityKernel
         return $bundles;
     }
 
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        parent::configureRoutes($routes);
+
+        foreach ($this->testRoutes as $route) {
+            if (\is_callable($route)) {
+                $route($routes);
+            } else {
+                $routes->import($route);
+            }
+        }
+    }
+
     protected function buildContainer(): ContainerBuilder
     {
         $container = parent::buildContainer();
@@ -115,6 +140,7 @@ class TestKernel extends CompatibilityKernel
         return hash('xxh3', json_encode([
             $this->testBundles,
             array_map(fn ($config) => \is_callable($config) ? self::closureHash($config(...)) : $config, $this->testConfigs),
+            array_map(fn ($config) => \is_callable($config) ? self::closureHash($config(...)) : $config, $this->testRoutes),
             $this->testExtensionConfigs,
             array_map(fn ($pass) => [$pass[0]::class, $pass[1], $pass[2]], $this->testCompilerPasses),
         ], \JSON_THROW_ON_ERROR));

--- a/src/Test/Attribute/ConfigureRoute.php
+++ b/src/Test/Attribute/ConfigureRoute.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Test\Attribute;
+
+use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class ConfigureRoute implements KernelConfiguration
+{
+    /**
+     * @param string|\Closure(RoutingConfigurator):void $config path to a config file or a closure which gets the {@see RoutingConfigurator} as its first argument
+     */
+    public function __construct(
+        private readonly string|\Closure $config,
+    ) {
+    }
+
+    public function configure(TestKernel $kernel): void
+    {
+        $kernel->addTestRoute($this->config);
+    }
+}

--- a/tests/Fixtures/Controller/ExampleController.php
+++ b/tests/Fixtures/Controller/ExampleController.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Tests\Fixtures\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ExampleController
+{
+    public function __invoke(Request $request): Response
+    {
+        return new Response('');
+    }
+}

--- a/tests/Fixtures/Resources/Routes/routes.php
+++ b/tests/Fixtures/Resources/Routes/routes.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+use Neusta\Pimcore\TestingFramework\Tests\Fixtures\Controller\ExampleController;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return function (RoutingConfigurator $routes): void {
+    $routes->add('example_route', '/example')
+        ->controller(ExampleController::class)
+    ;
+};

--- a/tests/Fixtures/Resources/Routes/routes.xml
+++ b/tests/Fixtures/Resources/Routes/routes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="example_route" path="/example"
+           controller="Neusta\Pimcore\TestingFramework\Tests\Fixtures\Controller\ExampleController"/>
+</routes>

--- a/tests/Fixtures/Resources/Routes/routes.yaml
+++ b/tests/Fixtures/Resources/Routes/routes.yaml
@@ -1,0 +1,3 @@
+example_route:
+  path: /example
+  controller: Neusta\Pimcore\TestingFramework\Tests\Fixtures\Controller\ExampleController

--- a/tests/Functional/RouteConfigurationTest.php
+++ b/tests/Functional/RouteConfigurationTest.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace Neusta\Pimcore\TestingFramework\Tests\Functional;
+
+use Neusta\Pimcore\TestingFramework\Kernel\TestKernel;
+use Neusta\Pimcore\TestingFramework\Test\Attribute\ConfigureRoute;
+use Neusta\Pimcore\TestingFramework\Test\ConfigurableKernelTestCase;
+use Neusta\Pimcore\TestingFramework\Tests\Fixtures\Controller\ExampleController;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\Component\Routing\Route;
+
+final class RouteConfigurationTest extends ConfigurableKernelTestCase
+{
+    public function provideDifferentConfigurationFormats(): iterable
+    {
+        yield 'YAML' => [__DIR__ . '/../Fixtures/Resources/Routes/routes.yaml'];
+        yield 'XML' => [__DIR__ . '/../Fixtures/Resources/Routes/routes.xml'];
+        yield 'PHP' => [__DIR__ . '/../Fixtures/Resources/Routes/routes.php'];
+        yield 'Callable' => [function (RoutingConfigurator $routes): void {
+            $routes->add('example_route', '/example')->controller(ExampleController::class);
+        }];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideDifferentConfigurationFormats
+     */
+    public function different_configuration_formats(string|callable $config): void
+    {
+        self::bootKernel(['config' => fn (TestKernel $kernel) => $kernel->addTestRoute($config)]);
+
+        self::assertRouteConfiguration(self::getContainer());
+    }
+
+    public function provideDifferentConfigurationFormatsViaKernelConfigurationObject(): iterable
+    {
+        yield 'YAML' => [new ConfigureRoute(__DIR__ . '/../Fixtures/Resources/Routes/routes.yaml')];
+        yield 'XML' => [new ConfigureRoute(__DIR__ . '/../Fixtures/Resources/Routes/routes.xml')];
+        yield 'PHP' => [new ConfigureRoute(__DIR__ . '/../Fixtures/Resources/Routes/routes.php')];
+        yield 'Callable' => [new ConfigureRoute(function (RoutingConfigurator $routes): void {
+            $routes->add('example_route', '/example')->controller(ExampleController::class);
+        })];
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider provideDifferentConfigurationFormatsViaKernelConfigurationObject
+     */
+    public function different_configuration_formats_via_data_provider(): void
+    {
+        self::assertRouteConfiguration(self::getContainer());
+    }
+
+    /**
+     * @test
+     */
+    #[ConfigureRoute(__DIR__ . '/../Fixtures/Resources/Routes/routes.yaml')]
+    public function configuration_in_yaml_via_attribute(): void
+    {
+        self::assertRouteConfiguration(self::getContainer());
+    }
+
+    /**
+     * @test
+     */
+    #[ConfigureRoute(__DIR__ . '/../Fixtures/Resources/Routes/routes.xml')]
+    public function configuration_in_xml_via_attribute(): void
+    {
+        self::assertRouteConfiguration(self::getContainer());
+    }
+
+    /**
+     * @test
+     */
+    #[ConfigureRoute(__DIR__ . '/../Fixtures/Resources/Routes/routes.php')]
+    public function configuration_in_php_via_attribute(): void
+    {
+        self::assertRouteConfiguration(self::getContainer());
+    }
+
+    public static function assertRouteConfiguration(ContainerInterface $container): void
+    {
+        $route = $container->get('router')->getRouteCollection()->get('example_route');
+
+        self::assertInstanceOf(Route::class, $route);
+        self::assertSame('/example', $route->getPath());
+    }
+}


### PR DESCRIPTION
Introduced a mechanism to configure routes dynamically in TestKernel using file paths, callables, or attribute-based configurations.