### PR TITLE
chore: allow insecure composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,9 @@
       "ergebnis/composer-normalize": true,
       "phpstan/extension-installer": true
     },
+    "audit": {
+      "block-insecure": false
+    },
     "preferred-install": "dist",
     "sort-packages": true
   },


### PR DESCRIPTION
Sadly, all Pimcore 10 & 11 versions have security issues... and we still support them.