### PR TITLE
task: add Symfony PHPUnit Bridge for better deprecation handling

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -104,6 +104,10 @@ jobs:
           PIMCORE_INSTANCE_IDENTIFIER: ${{ secrets.PIMCORE_INSTANCE_IDENTIFIER }}
           PIMCORE_PRODUCT_KEY: ${{ secrets.PIMCORE_PRODUCT_KEY }}
         run: |
+          if [ "${{ matrix.dependencies }}" = "lowest" ]; then
+            export SYMFONY_DEPRECATIONS_HELPER=disabled
+          fi
+
           if [ "${{ matrix.phpunit-version }}" = "^9.6" ]; then
             CONFIG="--configuration phpunit9.xml.dist"
           fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -108,5 +108,4 @@ jobs:
             CONFIG="--configuration phpunit9.xml.dist"
           fi
 
-          # Ignore deprecations with "8191" = E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED
-          php -d error_reporting=8191 vendor/bin/phpunit --fail-on-risky ${CONFIG:-}
+          composer tests -- ${CONFIG:-}

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "dependencies:check": "composer-dependency-analyser",
     "phpstan": "phpstan analyse --ansi",
     "phpstan:gitlab-ci": "phpstan analyse --ansi --no-interaction --no-progress --error-format=gitlab > .reports/phpstan.json",
-    "tests": "simple-phpunit",
+    "tests": "phpunit",
     "tests:coverage:gitlab-ci": "phpunit --colors=never --coverage-text --coverage-clover .reports/clover.xml --coverage-cobertura .reports/cobertura.xml --log-junit .reports/junit.xml"
   },
   "scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
     "phpstan/phpstan-phpunit": "^1.3.16",
     "phpstan/phpstan-symfony": "^1.3.8",
     "shipmonk/composer-dependency-analyser": "^1.7",
-    "symfony/http-foundation": "^6.4 || ^7.3"
+    "symfony/http-foundation": "^6.4 || ^7.3",
+    "symfony/phpunit-bridge": "^8.0"
   },
   "conflict": {
     "pimcore/pimcore": ">=11.2.0 <11.2.2"

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "dependencies:check": "composer-dependency-analyser",
     "phpstan": "phpstan analyse --ansi",
     "phpstan:gitlab-ci": "phpstan analyse --ansi --no-interaction --no-progress --error-format=gitlab > .reports/phpstan.json",
-    "tests": "phpunit",
+    "tests": "simple-phpunit",
     "tests:coverage:gitlab-ci": "phpunit --colors=never --coverage-text --coverage-clover .reports/clover.xml --coverage-cobertura .reports/cobertura.xml --log-junit .reports/junit.xml"
   },
   "scripts-descriptions": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,9 @@
     cacheDirectory=".phpunit.cache"
     colors="true"
     failOnRisky="true"
+    failOnNotice="true"
     failOnWarning="true"
+    failOnDeprecation="true"
 >
     <php>
         <ini name="display_startup_errors" value="On"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
         <ini name="display_startup_errors" value="On"/>
         <ini name="display_errors" value="On"/>
         <ini name="error_reporting" value="-1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;max[indirect]=999999&amp;quiet[]=indirect"/>
     </php>
 
     <testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,12 +7,14 @@
     bootstrap="tests/bootstrap.php"
     cacheDirectory=".phpunit.cache"
     colors="true"
+    failOnRisky="true"
     failOnWarning="true"
 >
     <php>
         <ini name="display_startup_errors" value="On"/>
         <ini name="display_errors" value="On"/>
         <ini name="error_reporting" value="-1"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>
@@ -31,5 +33,6 @@
 
     <extensions>
         <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
     </extensions>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,19 +4,21 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     beStrictAboutOutputDuringTests="true"
+    beStrictAboutChangesToGlobalState="true"
     bootstrap="tests/bootstrap.php"
     cacheDirectory=".phpunit.cache"
     colors="true"
     failOnRisky="true"
     failOnNotice="true"
     failOnWarning="true"
-    failOnDeprecation="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
 >
     <php>
         <ini name="display_startup_errors" value="On"/>
         <ini name="display_errors" value="On"/>
         <ini name="error_reporting" value="-1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;max[indirect]=999999&amp;quiet[]=indirect"/>
     </php>
 
     <testsuites>
@@ -35,6 +37,5 @@
 
     <extensions>
         <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
-        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
     </extensions>
 </phpunit>

--- a/phpunit9.xml.dist
+++ b/phpunit9.xml.dist
@@ -7,12 +7,14 @@
     bootstrap="tests/bootstrap.php"
     cacheResultFile=".phpunit.cache/test-results"
     colors="true"
+    failOnRisky="true"
     failOnWarning="true"
 >
     <php>
         <ini name="display_startup_errors" value="On"/>
         <ini name="display_errors" value="On"/>
         <ini name="error_reporting" value="-1"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
     </php>
 
     <testsuites>
@@ -30,4 +32,8 @@
     <extensions>
         <extension class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension"/>
     </extensions>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/phpunit9.xml.dist
+++ b/phpunit9.xml.dist
@@ -14,7 +14,7 @@
         <ini name="display_startup_errors" value="On"/>
         <ini name="display_errors" value="On"/>
         <ini name="error_reporting" value="-1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;max[indirect]=999999&amp;quiet[]=indirect"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;max[indirect]=999999&amp;quiet[]=indirect&amp;ignoreFile=./tests/deprecation-baseline.txt"/>
     </php>
 
     <testsuites>

--- a/phpunit9.xml.dist
+++ b/phpunit9.xml.dist
@@ -14,7 +14,7 @@
         <ini name="display_startup_errors" value="On"/>
         <ini name="display_errors" value="On"/>
         <ini name="error_reporting" value="-1"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0&amp;max[indirect]=999999&amp;quiet[]=indirect"/>
     </php>
 
     <testsuites>

--- a/tests/deprecation-baseline.txt
+++ b/tests/deprecation-baseline.txt
@@ -1,0 +1,16 @@
+# This file contains patterns to be ignored while testing for use of deprecated code.
+
+# Remaining "self" deprecation notices with Pimcore 11:
+%Since symfony/framework-bundle 6\.4: The "annotations\.\w+" service is deprecated without replacement%
+
+# Remaining "direct" deprecation notices with Pimcore 11:
+%Since symfony/serializer 6\.4: Passing a "Doctrine\\Common\\Annotations\\PsrCachedReader" instance as argument 1 to "Symfony\\Component\\Serializer\\Mapping\\Loader\\AttributeLoader::__construct\(\)" is deprecated, pass null or omit the parameter instead%
+%Since symfony/validator 6\.4: Method "Symfony\\Component\\Validator\\ValidatorBuilder::setDoctrineAnnotationReader\(\)" is deprecated without replacement%
+%Since symfony/routing 6\.4: Passing an instance of "Doctrine\\Common\\Annotations\\Reader" as first and the environment as second argument to "Symfony\\Component\\Routing\\Loader\\AttributeClassLoader::__construct" is deprecated\. Pass the environment as first argument instead%
+
+# Remaining "direct" deprecation notices with Pimcore 11 & 12:
+%Since pimcore/skeleton 11\.2\.0: For consistency purpose, it is recommended to use the autoload from Symfony Runtime in project root "bin/console"%
+%The "Pimcore\\Bundle\\InstallBundle\\Installer" class is considered internal\. It may change without further notice\. You should not use it from "Neusta\\Pimcore\\TestingFramework\\Database\\PimcoreInstaller"%
+
+# Remaining "direct" deprecation notices with Pimcore 12:
+%Since pimcore/admin-ui-classic-bundle 2\.3: The AdminUiClassicBundle is deprecated and will be discontinued with Pimcore Studio%


### PR DESCRIPTION
With Symfony's PHPUnit bridge, we can suppress only the deprecation warnings that we can't do anything about, rather than simply suppressing *all* deprecation warnings and effectively being blind in this regard.