### PR TITLE
feat(database): add conditional schema update based on `ENABLE_DOCTRINE_SCHEMA_UPDATE` env variable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
   ],
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+    "ext-filter": "*",
     "doctrine/persistence": "^3.1",
     "phpunit/phpunit": "^9.6 || ^10.5",
     "pimcore/admin-ui-classic-bundle": "^1.6 || ^2.0",

--- a/src/Database/PimcoreDatabaseResetter.php
+++ b/src/Database/PimcoreDatabaseResetter.php
@@ -94,7 +94,7 @@ final class PimcoreDatabaseResetter
             ]
         );
 
-        if (!self::isResetUsingDump() && $manager = $this->registry->getDefaultManagerName()) {
+        if (!self::isResetUsingDump() && self::shouldUpdateSchema() && $manager = $this->registry->getDefaultManagerName()) {
             ($this->runCommand)(
                 'doctrine:schema:update',
                 [
@@ -108,5 +108,10 @@ final class PimcoreDatabaseResetter
     private static function isResetUsingDump(): bool
     {
         return '' !== ($_SERVER['DATABASE_DUMP_LOCATION'] ?? '');
+    }
+
+    private static function shouldUpdateSchema(): bool
+    {
+        return true === filter_var($_SERVER['ENABLE_DOCTRINE_SCHEMA_UPDATE'] ?? 'true', \FILTER_VALIDATE_BOOL);
     }
 }


### PR DESCRIPTION
As `doctrine:schema:update` may drop Pimcore tables, we introduce an environment variable to skip it until we have a better solution.